### PR TITLE
feat: add NestJS 11 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,8 +25,8 @@
     "prettier:check": "prettier --check ."
   },
   "dependencies": {
-    "@nestjs/common": "^9.0.0 || ^10.0.0",
-    "@nestjs/core": "^9.0.0 || ^10.0.0"
+    "@nestjs/common": "^9.0.0 || ^10.0.0 || ^11.0.0",
+    "@nestjs/core": "^9.0.0 || ^10.0.0 || ^11.0.0"
   },
   "devDependencies": {
     "@riotbyte/eslint-config": "^0.1.2",


### PR DESCRIPTION
Widens `@nestjs/common` and `@nestjs/core` dependency ranges from `^9.0.0 || ^10.0.0` to `^9.0.0 || ^10.0.0 || ^11.0.0`